### PR TITLE
[IDEA] Use interactive prefix arg for number of pairs

### DIFF
--- a/query-replace-parallel.el
+++ b/query-replace-parallel.el
@@ -231,13 +231,11 @@ expression `\\,' feature or not.
 DELIM and BACKWARD are taken from the return value of the last
 call to `query-replace-read-args' and should be forwarded as the
 arguments to the query replacement functions."
-  (cl-loop for (from to delim backward)
-             = (query-replace-read-args
-                (query-replace-parallel--prompt regexp-flag) regexp-flag)
+  (cl-loop for i below (prefix-numeric-value current-prefix-arg)
+           for (from to delim backward)
+           = (query-replace-read-args
+              (query-replace-parallel--prompt regexp-flag) regexp-flag)
            for pair = (cons from to)
-           ;; NOTE: `query-replace-read-args' will return the last pair from
-           ;; history in case of empty input. That's our signal to stop reading.
-           until (member pair pairs)
            collect pair into pairs
            finally (cl-return (list pairs delim backward))))
 


### PR DESCRIPTION
Inspired by the suggestion from [your talk Q&A](https://emacsconf.org/2023/talks/parallel/) to use the prefix arg to determine how many times to prompt for replacements pairs.

This patch doesn't work because `current-prefix-arg` is already used in `query-replace`:

```
In interactive use, the prefix arg (non-nil DELIMITED in
non-interactive use), means replace only matches surrounded by
word boundaries.  A negative prefix arg means replace backward.
```

Seems like a niche use-case...

I still like the idea of having `query-replace-parallel` be a drop-in replacement for `query-replace`.  One potential option is to add a `transient` menu that would allow users to specify the number of queries as well as a value for `DELIMITED` and other parameters.

That's definitely outside the scope of this project though :)

Thanks!!!